### PR TITLE
Fix servo and tank code setup and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
-North Mesquite Best Robotics Code Soruce 
+# VEX Robotics Practice Suite
 
-Hello!
+## Overview
+This repository gathers small VEX programs that help test servo control and tank driving. Each script is ready to load through VEXcode and can be adjusted for classroom or workshop practice.
+
+## File Guide
+* `version1.py` lets the controller buttons move a servo to stored angles and returns it to center when the button is released.
+* `version2.py` provides a steady tank drive loop that mixes the vertical and horizontal joystick axes to command two drive motors.
+* `need_testing.h` shows a compact C plus plus example that sweeps a servo across left center and right positions while printing status on the brain screen.
+
+## Getting Started
+1. Open VEXcode in Python or C plus plus mode as needed.
+2. Create a new project and match the device setup to the ports shown in the script you plan to run.
+3. Copy the desired file contents into the project main file.
+4. Build and download to the brain, then test the behavior with the handheld controller.
+
+## Keeping This Guide Current
+Review this document whenever you push commits or edit the code. Update the descriptions above so that they match the latest behavior. Add any setup tips that future drivers or builders should know after new testing sessions.
+
+## Support Notes
+* Use the VEX device info view to confirm motor and servo ports before running code.
+* If you change controller bindings record the new button map inside the related file for clarity.
+* Share feedback from drivers after each practice so the code stays responsive.

--- a/need_testing.h
+++ b/need_testing.h
@@ -13,19 +13,19 @@ int main() {
 
   while (true) {
     // Move to far left (approximately 0°)
-    servoA.set_state(-100, percent);  // ~1ms pulse
+    servoA.setState(-100, percentUnits::pct);  // ~1ms pulse
     Brain.Screen.clearLine();
     Brain.Screen.print("Position: Left (-100%%)");
     wait(1000, msec);
 
     // Move to center (approximately 90°)
-    servoA.set_state(0, percent);     // ~1.5ms pulse
+    servoA.setState(0, percentUnits::pct);     // ~1.5ms pulse
     Brain.Screen.clearLine();
     Brain.Screen.print("Position: Center (0%%)");
     wait(1000, msec);
 
     // Move to far right (approximately 180°)
-    servoA.set_state(100, percent);   // ~2ms pulse
+    servoA.setState(100, percentUnits::pct);   // ~2ms pulse
     Brain.Screen.clearLine();
     Brain.Screen.print("Position: Right (100%%)");
     wait(1000, msec);

--- a/version2.py
+++ b/version2.py
@@ -1,11 +1,14 @@
 #region VEXcode Generated Robot Configuration
 from vex import *
 import urandom
-import math
 
 
 # wait for rotation sensor to fully initialize
 wait(30, MSEC)
+
+
+brain = Brain()
+controller = Controller()
 
 
 # Make random actually random
@@ -13,8 +16,9 @@ def initializeRandomSeed():
     wait(100, MSEC)
     random = brain.battery.voltage(MV) + brain.battery.current(CurrentUnits.AMP) * 100 + brain.timer.system_high_res()
     urandom.seed(int(random))
-      
-# Set random seed 
+
+
+# Set random seed
 initializeRandomSeed()
 
 
@@ -30,9 +34,6 @@ wait(200, MSEC)
 print("\033[2J")
 
 #endregion VEXcode Generated Robot Configuration
-
-brain=Brain()
-controller=Controller()
 
 motor_1 = Motor(PORT1)
 motor_2 = Motor(PORT2)


### PR DESCRIPTION
## Summary
- correct the servo sweep example to use the proper VEX pwm state API
- initialize the VEX brain before seeding randomness in the tank drive script
- rewrite the README with clearer guidance and upkeep instructions

## Testing
- not run
